### PR TITLE
Automatically install the linter package on activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ with files that have the `Go` syntax.
 
 ## Installation
 
-Linter package must be installed in order to use this plugin. If Linter is not
-installed, please follow the instructions
-[here][linter].
-
-### Plugin installation
-
 ```ShellSession
 $ apm install linter-golinter
 ```

--- a/init.coffee
+++ b/init.coffee
@@ -39,6 +39,8 @@ module.exports =
       default: '-min_confidence=0.8'
 
   activate: ->
+    require('atom-package-deps').install()
+
     linterName = 'linter-golinter'
 
     @subscriptions = new CompositeDisposable

--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
     "atom": ">=0.174.0"
   },
   "dependencies": {
-    "atom-linter": "^4.2.0"
+    "atom-linter": "^4.2.0",
+    "atom-package-deps": "^3.0.6"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Use the atom-package-deps module to automatically install the linter
package on first activation if not already present. Fixes #6