### PR TITLE
Move to eslint-config-airbnb-base and fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ matrix:
   include:
     - os: linux
       language: go
+      go: 1.6.2
     - os: linux
       language: go
+      go: 1.6.2
       env: ATOM_CHANNEL=beta
     - os: osx
       language: generic
@@ -39,6 +41,7 @@ git:
   depth: 10
 
 sudo: false
+group: edge
 
 addons:
   apt:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
   "homepage": "https://github.com/AtomLinter/linter-golinter",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.174.0"
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "scripts": {
+    "lint": "coffeelint lib && eslint spec",
+    "test": "apm test"
   },
   "dependencies": {
     "atom-linter": "^4.5.0",
@@ -26,19 +30,12 @@
   },
   "devDependencies": {
     "coffeelint": "^1.14.2",
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.0.2",
-    "eslint-plugin-react": "^4.1.0"
+    "eslint": "^2.9.0",
+    "eslint-config-airbnb-base": "^2.0.0",
+    "eslint-plugin-import": "^1.6.1"
   },
   "eslintConfig": {
-    "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-console": 0
-    },
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  'globals': {
-    'waitsForPromise': true
-  },
-  'env': {
-    'jasmine': true
+  env: {
+    atomtest: true,
+    jasmine: true
   }
 };

--- a/spec/linter-golinter-spec.js
+++ b/spec/linter-golinter-spec.js
@@ -2,12 +2,12 @@
 
 import * as path from 'path';
 
+const lint = require(path.join('..', 'lib', 'init.coffee')).provideLinter().lint;
+
 const goodPath = path.join(__dirname, 'fixtures', 'good.go');
 const errorsPath = path.join(__dirname, 'fixtures', 'errors.go');
 
 describe('The golint provider for Linter', () => {
-  const lint = require(path.join('..', 'lib', 'init.coffee')).provideLinter().lint;
-
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
     waitsForPromise(() => {


### PR DESCRIPTION
There is no need for the React components of the full eslint-config-airbnb.

Closes #44.
Closes #45.