### PR TITLE
Remove OS X Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,7 @@ matrix:
 
     - os: linux
       language: go
-      go: 1.8
-      env: ATOM_CHANNEL=beta
-
-    - os: osx
-      language: go
-      go: 1.8
-      env: ATOM_CHANNEL=stable
-
-    - os: osx
-      language: go
-      go: 1.8
+      go: 1.9
       env: ATOM_CHANNEL=beta
 
 install:

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,9 @@
-test:
-  override:
-    - ./build-package.sh
-
 dependencies:
   override:
     - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
     - chmod u+x build-package.sh
     - go get -u github.com/golang/lint/golint
+
+test:
+  override:
+    - ./build-package.sh


### PR DESCRIPTION
A few CI updates:
* Remove the OS X Travis CI builds
  * These take > 1 hour to queue on average and provide little to no benefit, as such they aren't worth the major headaches to trying to work on this repo.
* Update beta builds to use Go 1.9
* Reorder the CircleCI configuration